### PR TITLE
x509-parser.c: fix clang build

### DIFF
--- a/src/x509-parser.c
+++ b/src/x509-parser.c
@@ -3821,7 +3821,7 @@ out:
   @ ensures 0 <= \result <= 99;
   @ assigns \nothing;
   @*/
-u8 compute_decimal(u8 d, u8 u)
+static u8 compute_decimal(u8 d, u8 u)
 {
 	return (d - 0x30) * 10 + (u - 0x30);
 }
@@ -3980,7 +3980,7 @@ out:
   @ ensures 0 <= \result <= 9999;
   @ assigns \nothing;
   @*/
-u16 compute_year(u8 d1, u8 d2, u8 d3, u8 d4)
+static u16 compute_year(u8 d1, u8 d2, u8 d3, u8 d4)
 {
 	return ((u16)d1 - (u16)0x30) * 1000 +
 	       ((u16)d2 - (u16)0x30) * 100 +


### PR DESCRIPTION
Clang fails to build the project. This patch fixes the problem.

```
$ clang --version
clang version 8.0.0 (tags/RELEASE_800/final)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/lib/llvm/8/bin

$ CC=clang make
clang -Weverything -Werror -Wno-reserved-id-macro -Wno-unreachable-code-break -Wno-covered-switch-default -Wno-padded -pedantic -fno-builtin -std=c99 -D_FORTIFY_SOURCE=2 -fstack-protector-strong -O3 -fPIC -ffreestanding -c src/x509-parser.c -o build/x509-parser.o
src/x509-parser.c:3824:4: error: no previous prototype for function 'compute_decimal' [-Werror,-Wmissing-prototypes]
u8 compute_decimal(u8 d, u8 u)
   ^
src/x509-parser.c:3983:5: error: no previous prototype for function 'compute_year' [-Werror,-Wmissing-prototypes]
u16 compute_year(u8 d1, u8 d2, u8 d3, u8 d4)
    ^
2 errors generated.
make: *** [Makefile:19: build/x509-parser.o] Error 1
```