### PR TITLE
Add an entry point in the code and a Makefile target for IKOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,4 +76,16 @@ frama-c:
 frama-c-gui:
 	frama-c-gui -load $(SESSION)
 
-.PHONY: all clean frama-c-gui frama-c
+#####################################################################
+# IKOS
+#####################################################################
+
+IKOS_DATABASE:=ikos.db
+
+ikos:
+	ikos src/x509-parser.c -D__IKOS__ -o $(IKOS_DATABASE)
+
+ikos-gui:
+	ikos-view $(IKOS_DATABASE)
+
+.PHONY: all clean frama-c-gui frama-c ikos ikos-gui

--- a/README.md
+++ b/README.md
@@ -37,8 +37,12 @@ This will compile different elements in the [build](build/) directory:
 
 ## Validating
 
-The main [Makefile](Makefile) has a Frama-C target which can be used to
-start Frama-C to verify the project.
+The main [Makefile](Makefile) has targets to run several static analyzers.
+
+### Frama-C
+
+To verify the project with [Frama-C](https://frama-c.com/), use the `frama-c`
+target:
 
 <pre>
 	$ make frama-c
@@ -49,3 +53,14 @@ Frama-C can be done using OPAM. More details can be found on
 [Frama-C](https://frama-c.com/) project website. Frama-C may also be
 available as a common package on your distribution.
 
+### IKOS
+
+To verify the project with [IKOS](https://github.com/NASA-SW-VnV/ikos), use the
+`ikos` target:
+
+<pre>
+	$ make ikos
+</pre>
+
+IKOS must have been installed prior to calling that target.
+See the [installation instructions](https://github.com/NASA-SW-VnV/ikos/tree/master/doc/install).

--- a/src/x509-parser.c
+++ b/src/x509-parser.c
@@ -9222,7 +9222,7 @@ out:
 	return ret;
 }
 
-#ifdef __FRAMAC__
+#if defined(__FRAMAC__)
 
 /* This dummy main allows testing */
 
@@ -9239,6 +9239,26 @@ int main(int argc, char *argv[]) {
 
 	len = Frama_C_interval(0, RAND_BUF_SIZE);
 	/*@ assert 0 <= len <= RAND_BUF_SIZE; */
+
+	ret = parse_x509_cert(buf, len);
+
+	return ret;
+}
+
+#elif defined(__IKOS__)
+
+#include <ikos/analyzer/intrinsic.h>
+#define RAND_BUF_SIZE 65535
+
+int main(int argc, char *argv[]) {
+	u8 buf[RAND_BUF_SIZE];
+	u16 len;
+	int ret;
+
+	__ikos_abstract_mem(buf, RAND_BUF_SIZE);
+
+	len = __ikos_nondet_uint();
+	__ikos_assume(len <= RAND_BUF_SIZE);
 
 	ret = parse_x509_cert(buf, len);
 


### PR DESCRIPTION
This pull request performs the following changes:
* Add a `main()` entry point for IKOS, similar to the `main()` for Frama-C
* Add an `ikos` and `ikos-gui` target in the `Makefile`
* Add documentation on how to use the `ikos` target in the `README.md`