### PR TITLE
Add missing variant in bufs_differ

### DIFF
--- a/src/x509-parser.c
+++ b/src/x509-parser.c
@@ -58,6 +58,7 @@ static int bufs_differ(const u8 *b1, const u8 *b2, u16 n)
 	  @ loop invariant 0 <= i <= n;
 	  @ loop invariant bmatch(b1, b2, i);
 	  @ loop assigns i;
+	  @ loop variant n - i;
 	  @*/
 	for (i = 0; i < n; i++) {
 		if(b1[i] != b2[i]) {


### PR DESCRIPTION
This MR adds a missing variant clause on a loop.

This missing variant was discovered with the new WP experimental support of `terminates` clause in Frama-C 24. With this variant, adding the options:

```
-wp-definitions-terminate \
-wp-declarations-terminate \
-wp-frama-c-stdlib-terminate \
```

allows to prove that all functions in the parser terminate.